### PR TITLE
Named parameters and fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC        := g++
 LD        := g++
 AR        := ar
 
-CPPFLAGS  := -std=c++0x -O3 -Wall -fmessage-length=0 -fPIC
+CPPFLAGS  := -std=c++14 -O3 -Wall -fmessage-length=0 -fPIC
 LDFLAGS   := -lfbclient -lpthread
 
 MODULES   := fb test

--- a/src/fb/DbRowProxy.cpp
+++ b/src/fb/DbRowProxy.cpp
@@ -242,13 +242,13 @@ std::string DbRowProxy::getText(unsigned int idx) const
         break;
     case SQL_ARRAY:
         u1.iquad = ((const ISC_QUAD*) v1.sqldata);
-        snprintf(convBuf, sizeof(convBuf), "array %x:%x",
+        snprintf(convBuf, sizeof(convBuf), "array %lx:%lx",
                 u1.iquad->gds_quad_high, u1.iquad->gds_quad_low);
         buf = convBuf;
         break;
     case SQL_QUAD:
         u1.iquad = ((const ISC_QUAD*) v1.sqldata);
-        snprintf(convBuf, sizeof(convBuf), "%08x:%08x",
+        snprintf(convBuf, sizeof(convBuf), "%08lx:%08lx",
                 u1.iquad->gds_quad_high, u1.iquad->gds_quad_low);
         buf = convBuf;
         break;

--- a/src/fb/DbRowProxy.h
+++ b/src/fb/DbRowProxy.h
@@ -64,8 +64,8 @@ private:
 class DbField {
     //friend class DbRowProxy;
 private:
-    SqlDescriptorArea *row_;
     DbRowProxy* rowProxy;
+    SqlDescriptorArea *row_;
     unsigned int idx;
 public:
     DbField(DbRowProxy* rowProxy, SqlDescriptorArea *row, unsigned int idx) 

--- a/src/fb/DbRowProxy.h
+++ b/src/fb/DbRowProxy.h
@@ -20,10 +20,20 @@
 #include <string>
 #include "FbCommon.h"
 
+#include "FbInternals.h"
+#include "FbException.h"
+#include <memory>
+#include <time.h>
+#include <iomanip>
+#include <unordered_map>
+
 namespace fb {
 
 // forward declarations
 class DbBlob;
+class DbField; 
+
+using DbFieldPtr = std::shared_ptr<DbField>; // max68
 
 class DbRowProxy
 {
@@ -40,14 +50,60 @@ public:
     int64_t getInt64(unsigned int idx) const;
     std::string getText(unsigned int idx) const;
     DbBlob getBlob(unsigned int idx) const;
-
+    DbFieldPtr fieldByName(const std::string& name);
 private:
+    std::unordered_map<std::string, DbFieldPtr> fields;
     DbRowProxy(SqlDescriptorArea *sqlda, FbApiHandle db, FbApiHandle tr);
 
     /** row_ is not owned by this */
     SqlDescriptorArea *row_;
     FbApiHandle db_;
     FbApiHandle transaction_;
+};
+
+class DbField {
+    //friend class DbRowProxy;
+private:
+    SqlDescriptorArea *row_;
+    DbRowProxy* rowProxy;
+    unsigned int idx;
+public:
+    DbField(DbRowProxy* rowProxy, SqlDescriptorArea *row, unsigned int idx) 
+    :rowProxy(rowProxy), row_(row), idx(idx){};
+
+    int64_t asInteger() {
+        return rowProxy->getInt64(idx);
+    }
+
+    double asDouble() {
+        return std::strtod(rowProxy->getText(idx).c_str(), nullptr);
+    }
+
+    std::string asString() {
+        return rowProxy->getText(idx);
+    }
+
+    std::string formatDate(const std::string &format = "%Y-%m-%d") {
+
+        struct tm times;
+        const XSQLVAR &v1 = row_->sqlvar[idx];
+        
+        switch (v1.sqltype & ~1){
+            case SQL_TYPE_DATE:
+                isc_decode_sql_date((ISC_DATE *) v1.sqldata, &times);
+                break;
+            case SQL_TIMESTAMP:
+                isc_decode_timestamp((ISC_TIMESTAMP *) v1.sqldata, &times);
+                break;
+            default:
+            throw FbException("Incompatible types.", nullptr);
+        }
+
+        char buff[30];
+        strftime(buff, 30, format.c_str(), &times);
+
+        return buff;
+    }
 };
 
 } /* namespace fb */

--- a/src/fb/DbStatement.cpp
+++ b/src/fb/DbStatement.cpp
@@ -29,7 +29,7 @@
 
 #include <algorithm>
 #include <cctype>
-
+#include <cmath>
 
 namespace fb
 {
@@ -407,6 +407,15 @@ void DbStatement::setDouble(unsigned int idx, double v) {
             break;
         case SQL_DOUBLE:
             *((double*) v1.sqldata) = v;
+            break;
+        case SQL_SHORT:
+            *((int16_t*) v1.sqldata) = (int16_t)floor( v + 0.5);
+            break;
+        case SQL_LONG:
+            *((ISC_LONG*) v1.sqldata) = (ISC_LONG)floor( v + 0.5);
+            break;
+        case SQL_INT64:
+            *((int64_t*) v1.sqldata) = (int64_t)floor( v + 0.5);
             break;
         default:
             throw std::invalid_argument("invalid data type for bound parameter!");

--- a/src/fb/DbStatement.cpp
+++ b/src/fb/DbStatement.cpp
@@ -27,6 +27,9 @@
 #include <memory>
 #include <string.h>
 
+#include <algorithm>
+#include <cctype>
+
 
 namespace fb
 {
@@ -130,8 +133,51 @@ DbStatement::DbStatement(FbApiHandle *db,
     results_->sqld = 1;
     results_->version = SQLDA_VERSION1;
 
+    // preprocess sql for named parameters
+    int i = 0;
+    int j = 0;
+    int k = 0;
+    int cntPar = 0;
+    int l = strlen(sql);
+    char pSql[l];
+    char paramName[32];
+    while (sql[i] != '\0') {
+        switch (sql[i]) {
+            case '?':
+                pSql[j++] = sql[i++];
+                ++cntPar;
+                break;
+            case '\'':
+                pSql[j++] = sql[i++];
+                while (sql[i] != '\0' && sql[i] != '\'')
+                    pSql[j++] = sql[i++];
+                if (sql[i] == '\0')
+                    throw FbException("Preprocessing SQL error.", nullptr);
+                else
+                    pSql[j++] = sql[i++];
+                break;
+            case ':':
+                k = 0;
+                pSql[j++] = '?';
+                ++i;
+                while (std::isalpha(sql[i]) || std::isdigit(sql[i]) || sql[i] == '_') {
+                    paramName[k++] = std::toupper(sql[i++]);
+                }
+                if (k > 0 && k < 32) {
+                    paramName[k] = '\0';
+                    namedParameters[paramName] = ++cntPar;
+                } else
+                    throw FbException("Preprocessing SQL error.", nullptr);
+                break;
+            default:
+                pSql[j++] = sql[i++];
+                break;
+        }
+    }
+    pSql[j] = '\0';
+    
     if (isc_dsql_prepare(status, trans_->nativeHandle(), &statement_, 0,
-                        sql, (short) FB_SQL_DIALECT, results_)) {
+                        pSql, (short) FB_SQL_DIALECT, results_)) {
         throw FbException("Failed to prepare statement.", status);
     }
 
@@ -189,6 +235,7 @@ DbStatement::DbStatement(DbStatement &&st)
     ownsTransaction_ = st.ownsTransaction_;
     cursorOpened_ = st.cursorOpened_;
     statementType_ = st.statementType_;
+    namedParameters = st.namedParameters;
 
     st.results_ = nullptr;
     st.fields_ = nullptr;
@@ -212,6 +259,7 @@ DbStatement &DbStatement::operator=(DbStatement &&st)
     ownsTransaction_ = st.ownsTransaction_;
     cursorOpened_ = st.cursorOpened_;
     statementType_ = st.statementType_;
+    namedParameters = st.namedParameters;
 
     st.results_ = nullptr;
     st.fields_ = nullptr;
@@ -348,6 +396,21 @@ void DbStatement::setInt(unsigned int idx, int64_t v)
     default:
         throw std::invalid_argument("invalid data type for bound parameter!");
         break;
+    }
+}
+
+void DbStatement::setDouble(unsigned int idx, double v) {
+    XSQLVAR &v1 = getSqlVarCheckIndex(idx, true);
+    switch (v1.sqltype & ~1) {
+        case SQL_FLOAT:
+            *((float*) v1.sqldata) = v;
+            break;
+        case SQL_DOUBLE:
+            *((double*) v1.sqldata) = v;
+            break;
+        default:
+            throw std::invalid_argument("invalid data type for bound parameter!");
+            break;
     }
 }
 
@@ -540,6 +603,19 @@ DbRowProxy DbStatement::Iterator::operator*()
     return DbRowProxy(st_->results_,
                       st_->db_,
                       *st_->trans_->nativeHandle());
+}
+
+StParameterPtr DbStatement::paramByName(const std::string& name) {
+    std::string Uname = name;
+    std::transform(Uname.begin(), Uname.end(), Uname.begin(),
+            [](unsigned char c) {
+                return std::toupper(c); }
+    );
+    auto it = namedParameters.find(Uname);
+    if (it == namedParameters.end())
+        throw FbException("Could not find matching parameter.", nullptr);
+
+    return std::make_unique<StParameter>(this, it->second);
 }
 
 } /* namespace fb */

--- a/src/fb/DbStatement.h
+++ b/src/fb/DbStatement.h
@@ -138,6 +138,21 @@ private:
 public:
     StParameter(DbStatement* st, unsigned int idx): st_(st), idx_(idx){};
 
+    void setValue(short int v) { st_->setInt(idx_, v); };
+    void setValue(unsigned short int v) { st_->setInt(idx_, v); };
+    void setValue(int v) { st_->setInt(idx_, v); };
+    void setValue(unsigned int v) { st_->setInt(idx_, v); };
+    void setValue(long int v) { st_->setInt(idx_, v); };
+    void setValue(unsigned long int v) { st_->setInt(idx_, v); };
+    void setValue(long long int v) { st_->setInt(idx_, v); };
+    void setValue(unsigned long long int v) { st_->setInt(idx_, v); };
+
+
+    void setValue(float v)   { st_->setDouble(idx_, v); };
+    void setValue(double v)  { st_->setDouble(idx_, v); };
+    void setValue(const char* v){ st_->setText(idx_, v); };
+    void setValue(const DbBlob &v) { st_->setBlob(idx_, v); };
+    
     void setInt(int64_t v){
         st_->setInt(idx_, v);
     }

--- a/src/fb/DbStatement.h
+++ b/src/fb/DbStatement.h
@@ -20,6 +20,8 @@
 
 #include <memory>
 #include <unordered_map>
+#include <typeinfo>
+#include <typeindex>
 
 namespace fb
 {
@@ -136,24 +138,21 @@ private:
 public:
     StParameter(DbStatement* st, unsigned int idx): st_(st), idx_(idx){};
 
-    void setValue(int v){
+    void setInt(int64_t v){
         st_->setInt(idx_, v);
     }
-    void setValue(int64_t v){
-        st_->setInt(idx_, v);
-    }
-    void setValue(double v){
+    void setDouble(double v){
         st_->setDouble(idx_, v);
     }
-    void setValue(const char* v){
+    void setText(const char* v){
         st_->setText(idx_, v);
     }
     void setNull(){
         st_->setNull(idx_);
     }
-    void setValue(const DbBlob &v){
+    void setBlob(const DbBlob &v){
         st_->setBlob(idx_, v);
-    }
+    } 
 };
 
 } /* namespace fb */

--- a/src/fb/FbCommon.cpp
+++ b/src/fb/FbCommon.cpp
@@ -14,7 +14,6 @@
  */
 
 #include "FbCommon.h"
-#include <ibase.h>
 
 namespace fb
 {

--- a/src/fb/FbCommon.h
+++ b/src/fb/FbCommon.h
@@ -16,14 +16,15 @@
 #ifndef DBWRAP__FB_FBCOMMON_H_
 #define DBWRAP__FB_FBCOMMON_H_
 
+#include <ibase.h>
+
 namespace fb
 {
 
 /**
- * FbApiHandle is an alias for FB_API_HANDLE (must be the same type as
- * FB_API_HANDLE). We use FbApiHandle so we don't have to include ibase.h
- */
-typedef unsigned int FbApiHandle;
+ * FbApiHandle is an alias for FB_API_HANDLE
+ */ 
+typedef FB_API_HANDLE FbApiHandle;
 
 /**
  * SqlDescriptorArea is a placeholder for XSQLDA. We use SqlDescriptorArea

--- a/src/fb/FbException.cpp
+++ b/src/fb/FbException.cpp
@@ -20,7 +20,7 @@
 namespace fb {
 
 /** status should be an ISC_STATUS_ARRAY from ibase.h */
-FbException::FbException(const char *operation, const long *status) :
+FbException::FbException(const char *operation, ISC_STATUS_ARRAY status) :
                                 std::runtime_error("Firebird exception!")
 {
     if (!status) {

--- a/src/fb/FbException.h
+++ b/src/fb/FbException.h
@@ -16,6 +16,7 @@
 #define DBWRAP__FB_FBEXCEPTION_H_
 
 #include <stdexcept>
+#include <ibase.h>
 
 namespace fb {
 
@@ -23,7 +24,7 @@ class FbException : public std::runtime_error
 {
 public:
     /** status should be an ISC_STATUS_ARRAY from ibase.h */
-    FbException(const char *operation, const long *status);
+    FbException(const char *operation, ISC_STATUS_ARRAY status); //max68
     virtual ~FbException() noexcept;
     virtual const char *what() const noexcept;
 

--- a/src/test/FbDbUnitTest.cpp
+++ b/src/test/FbDbUnitTest.cpp
@@ -171,9 +171,9 @@ void populate_database()
     DbStatement dbs1 = dbc.createStatement(
             "INSERT INTO TEST1 (IID, I64_1, VAL4) VALUES (:IID, :I64_1, :VAL4) RETURNING (IID)",
             &trans);
-    dbs1.paramByName("IID")->setValue(100);
-    dbs1.paramByName("I64_1")->setValue(100);
-    dbs1.paramByName("VAL4")->setValue("a hundred");
+    dbs1.paramByName("IID")->setInt(100);
+    dbs1.paramByName("I64_1")->setInt(100);
+    dbs1.paramByName("VAL4")->setText("a hundred");
     dbs1.execute();
 
     // by committing the transaction we're not allowed to use it
@@ -257,7 +257,7 @@ void select_prepared_statements_tests()
     DbStatement dbs4 = dbc.createStatement(
                         "SELECT r.* FROM TEST1 r WHERE r.IID=:iid", &tr2);
 
-    dbs4.paramByName("iid")->setValue(100);
+    dbs4.paramByName("iid")->setInt(100);
     count = 0;
     for (DbStatement::Iterator i = dbs4.iterate(); i != dbs2.end(); ++i) {
         DbRowProxy row = *i;
@@ -312,7 +312,7 @@ void blob_tests()
     st.setInt(1, 1);
     st.setText(2, "val1");
     st.setBlob(3, blob);
-    st.paramByName("MEMO_COPY")->setValue(blob);
+    st.paramByName("MEMO_COPY")->setBlob(blob);
     st.execute();
 
     // repeat the insert statement with different parameters

--- a/src/test/FbDbUnitTest.cpp
+++ b/src/test/FbDbUnitTest.cpp
@@ -24,13 +24,8 @@
 #include <cstring>
 #include <unistd.h>
 
-static char g_dbName[200] = "e:\\database\\eco.gdb";
-static char g_dbServer[200] = "10.10.10.80";
-
-/*
 static char g_dbName[200] = "/tmp/DbWrap++FB_LKzgBZOx.fdb";
 static char g_dbServer[200] = "localhost";
-*/
 static char g_dbUserName[100] = "sysdba";
 static char DB_PASSWORD[32] = "masterkey";
 

--- a/src/test/FbDbUnitTest.cpp
+++ b/src/test/FbDbUnitTest.cpp
@@ -24,9 +24,13 @@
 #include <cstring>
 #include <unistd.h>
 
+static char g_dbName[200] = "e:\\database\\eco.gdb";
+static char g_dbServer[200] = "10.10.10.80";
 
+/*
 static char g_dbName[200] = "/tmp/DbWrap++FB_LKzgBZOx.fdb";
 static char g_dbServer[200] = "localhost";
+*/
 static char g_dbUserName[100] = "sysdba";
 static char DB_PASSWORD[32] = "masterkey";
 
@@ -171,9 +175,9 @@ void populate_database()
     DbStatement dbs1 = dbc.createStatement(
             "INSERT INTO TEST1 (IID, I64_1, VAL4) VALUES (:IID, :I64_1, :VAL4) RETURNING (IID)",
             &trans);
-    dbs1.paramByName("IID")->setInt(100);
-    dbs1.paramByName("I64_1")->setInt(100);
-    dbs1.paramByName("VAL4")->setText("a hundred");
+    dbs1.paramByName("IID")->setValue(100);
+    dbs1.paramByName("I64_1")->setValue(100);
+    dbs1.paramByName("VAL4")->setValue("a hundred");
     dbs1.execute();
 
     // by committing the transaction we're not allowed to use it
@@ -257,7 +261,7 @@ void select_prepared_statements_tests()
     DbStatement dbs4 = dbc.createStatement(
                         "SELECT r.* FROM TEST1 r WHERE r.IID=:iid", &tr2);
 
-    dbs4.paramByName("iid")->setInt(100);
+    dbs4.paramByName("iid")->setValue(100);
     count = 0;
     for (DbStatement::Iterator i = dbs4.iterate(); i != dbs2.end(); ++i) {
         DbRowProxy row = *i;
@@ -312,7 +316,7 @@ void blob_tests()
     st.setInt(1, 1);
     st.setText(2, "val1");
     st.setBlob(3, blob);
-    st.paramByName("MEMO_COPY")->setBlob(blob);
+    st.paramByName("MEMO_COPY")->setValue(blob);
     st.execute();
 
     // repeat the insert statement with different parameters
@@ -397,10 +401,10 @@ void print_all_datatypes()
         DbRowProxy row = *i;
         printf("%02d ------------------\n", count++);
 
-        printf("ID     : %ld\n", row.fieldByName("ID")->asInteger());  
-        printf("ATTR_ID: %ld\n", row.fieldByName("ATTR_ID")->asInteger());  
-        printf("OBJ_ID : %ld\n", row.fieldByName("OBJ_ID")->asInteger());  
-        printf("INT_VAL: %ld\n", row.fieldByName("INT_VAL")->asInteger());  
+        printf("ID     : %lld\n", row.fieldByName("ID")->asInteger());  
+        printf("ATTR_ID: %lld\n", row.fieldByName("ATTR_ID")->asInteger());  
+        printf("OBJ_ID : %lld\n", row.fieldByName("OBJ_ID")->asInteger());  
+        printf("INT_VAL: %lld\n", row.fieldByName("INT_VAL")->asInteger());  
         printf("STR_VAL: %s\n", row.fieldByName("STR_VAL")->asString().c_str());  
 
         printf("DATE_VAL: %s\n", row.fieldByName("DATE_VAL")->formatDate().c_str());  


### PR DESCRIPTION
I have tested DBWrap-FB on a raspberry pi 3. It didn't work because FB_API_HANDLE is defined unsigned int for 64-bit systems and void* otherwise. So I did a few  changes to do it working. 

I did other changes to support named parameters and fields. That avoids to remember the right position of a parameter/field and, in my opinion, makes the code more readable.

I hope you'll find my contribute opportune. :)